### PR TITLE
Rewrite the review chapter for the R-native review flow (S5)

### DIFF
--- a/docs/entrypoints.md
+++ b/docs/entrypoints.md
@@ -19,7 +19,7 @@ This repository is a Carpentries/Sandpaper lesson for the Salmon Data Standards 
 
 ## Software lanes
 
-- R instructions use the latest `metasalmon` from the repository without a version pin.
+- R instructions use the latest `metasalmon` from the repository without a version pin. The *lesson build* is a separate matter: `renv/profiles/lesson-requirements/renv.lock` pins one released `metasalmon`, and that pin must be bumped whenever an episode starts teaching a newer function. `episodes/session-4.Rmd` writes a note to the build log when the pin is behind what it teaches.
 - Python instructions use the latest `metasalmonpy` from the repository without a version pin.
 - Spreadsheet instructions use the same canonical SDP CSV files and appear separately where no code is required.
 - `metasalmon` and `metasalmonpy` are treated as behaviorally aligned implementations; deliberate language differences belong in the upstream parity guide.
@@ -29,7 +29,7 @@ This repository is a Carpentries/Sandpaper lesson for the Salmon Data Standards 
 1. `episodes/session-1.Rmd`: introduce the salmon data integration system, its SDP and software components, shared and local semantic resources, bounded contexts, and the SDP-to-EML publication direction.
 2. `episodes/session-2.Rmd`: run a prepared quickstart in the selected R, Python, or Spreadsheet lane and inspect the resulting package structure.
 3. `episodes/session-3.Rmd`: bring learner-owned single-table, multi-CSV, or multi-sheet Excel inputs into a reproducible R or Python build script, declare context inputs, seed semantic candidates, and encode accepted review decisions for reruns.
-4. `episodes/session-4.Rmd`: use the shared NuSEDS Fraser Coho example to review one measurement IRI, one I-ADOPT decomposition, one unit, one table observation-unit IRI, and one method-code IRI, with optional bundle-aware LLM review.
+4. `episodes/session-4.Rmd`: use the shared NuSEDS Fraser Coho example to run metasalmon's R-native semantic review — `review_semantics()` prints the decision call, the learner pastes it into the build script, and `apply_sdp_semantics()` writes it — covering one measurement IRI, one I-ADOPT decomposition, one unit, one statistical modifier, one table observation-unit IRI, and one deliberate rejection, with optional bundle-aware LLM review named as a separate opt-in.
 5. `episodes/session-5.Rmd`: code lists, SKOS, and local vocabulary.
 6. `episodes/session-6.Rmd`: render SMN, GCDFO, profile, or skip routes; write validated EML; preview KNB publication; and create a later version without discarding reviewed metadata.
 7. `episodes/bonus-session.Rmd`: optional concept mapping extension.

--- a/docs/entrypoints.md
+++ b/docs/entrypoints.md
@@ -19,8 +19,8 @@ This repository is a Carpentries/Sandpaper lesson for the Salmon Data Standards 
 
 ## Software lanes
 
-- R instructions use the latest `metasalmon` from the repository without a version pin. The *lesson build* is a separate matter: `renv/profiles/lesson-requirements/renv.lock` pins one released `metasalmon`, and that pin must be bumped whenever an episode starts teaching a newer function. `episodes/session-4.Rmd` writes a note to the build log when the pin is behind what it teaches.
-- Python instructions use the latest `metasalmonpy` from the repository without a version pin.
+- R instructions pin `metasalmon` to the **`v0.5.0`** release tag, and `renv/profiles/lesson-requirements/renv.lock` pins the same release, so a learner's install and the lesson build are the same package. Bump the two together — `learners/setup.md` and the lockfile — whenever an episode starts teaching a newer function. The build-log note `episodes/session-4.Rmd` used to emit when the pin was behind what it taught has been removed; the pin is no longer behind, and that was the condition the note named for its own retirement.
+- Python instructions pin `metasalmonpy` to the **`v0.4.0`** release tag tarball (its releases carry no wheel assets). **The two lanes are deliberately on different numbers**: the R-native review flow `episodes/session-4.Rmd` teaches shipped in metasalmon 0.5.0 and has not been ported to Python, so that episode's Python lane is empty and says so. Pinning fixes reproducibility on both lanes; only the port closes the capability gap.
 - Spreadsheet instructions use the same canonical SDP CSV files and appear separately where no code is required.
 - `metasalmon` and `metasalmonpy` are treated as behaviorally aligned implementations; deliberate language differences belong in the upstream parity guide.
 

--- a/episodes/session-2.Rmd
+++ b/episodes/session-2.Rmd
@@ -134,7 +134,7 @@ Keep the copied folder structure and header rows unchanged. In this chapter, ins
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-For the R and Python lanes, `seed_semantics = FALSE` / `seed_semantics=False` is the fast classroom option. It skips live searches for links to shared definitions. Chapter 4 shows how to run those searches after the starter metadata has been reviewed.
+For the R and Python lanes, `seed_semantics = FALSE` / `seed_semantics=False` is the fast classroom option. It skips live searches for links to shared definitions. Chapter 3 turns those searches on once the starter metadata has been reviewed, and Chapter 4 decides the candidates they return.
 
 ## Inspect the package files
 

--- a/episodes/session-3.Rmd
+++ b/episodes/session-3.Rmd
@@ -284,13 +284,18 @@ The complete workflow will grow across the remaining chapters:
 | --- | --- |
 | Read and transform | Read unchanged source files and express every tidy-data transformation in R or Python. |
 | Create a draft | Run `create_sdp()` with `seed_semantics = TRUE` / `seed_semantics=True`. |
-| Review | Read the package with `read_salmon_datapackage()` and represent accepted metadata decisions as code. |
-| Write | Write the reviewed state with `write_salmon_datapackage()`. Use a versioned path when the earlier package must be preserved. |
+| Review free text | Read the package with `read_salmon_datapackage()` and represent accepted description, contact, and licence decisions as code. |
+| Review semantics | In R, decide each suggested IRI with `review_semantics()` and `accept_suggestion()` in Chapter 4, and write them with `apply_sdp_semantics()`. |
+| Write | Write reviewed free-text state with `write_salmon_datapackage()`. Use a versioned path when the earlier package must be preserved. |
 | Check | Run `validate_salmon_datapackage()` and fix the script or its declared inputs, then rerun. |
 
-In this script-backed workflow, `overwrite = TRUE` / `overwrite=True` deliberately rebuilds writer-managed files and then reapplies the decisions encoded below it. A manual edit that exists only in the generated folder can be replaced, which is why reviewed changes belong in the script or in a preserved, versioned package. Do not use `prune = TRUE` / `prune=True` here.
+Two writers appear in that table, and they are not interchangeable. `write_salmon_datapackage()` rebuilds a whole package from in-memory objects, which is what a free-text edit needs. `apply_sdp_semantics()`, introduced in Chapter 4, changes only the decided cells and leaves every data CSV byte untouched, which is what a semantic decision needs.
 
-The following small extension shows the pattern. Later chapters add semantic review, EML export, and publication steps to the same workflow.
+In this script-backed workflow, `overwrite = TRUE` / `overwrite=True` deliberately rebuilds writer-managed files and then reapplies the decisions encoded below it. A manual edit that exists only in the generated folder can be replaced, which is why reviewed changes belong in the script or in a preserved, versioned package.
+
+Do not use `prune = TRUE` / `prune=True` here, and Chapter 4 is where you would find out why: pruning deletes `semantic_suggestions.csv`, and with it the entire evidence base the semantic review reads. `review_semantics()` then reports that there is nothing to review, and the only way back is a full reseeding search.
+
+The following small extension shows the free-text pattern. Later chapters add semantic review, EML export, and publication steps to the same workflow.
 
 ::::::::::::::::::::::::::::::::::::: group-tab
 
@@ -483,6 +488,7 @@ Rerun the script to confirm that the declared inputs and encoded review decision
 - One dataset may contain one or many tables; pass multiple tables as a named list.
 - Prepare tidy rectangular inputs: one variable per column, one observation per row, and one value per cell.
 - Semantic seeding is enabled in this chapter; LLM assessment remains a separate, explicit opt-in.
+- Seeding is what makes Chapter 4 possible: the review there reads suggestions rather than searching, so a package built without seeding has nothing to review.
 - Metadata tables hold structured facts; README/context notes hold narrative caveats.
 - A clear description is more valuable than an uncertain link to a shared definition.
 

--- a/episodes/session-4.Rmd
+++ b/episodes/session-4.Rmd
@@ -6,192 +6,306 @@ exercises: 40
 
 :::::::::::::::::::::::::::::::::::::: questions
 
+- Where does the record of a semantic decision live?
 - How do we keep semantic review small enough to finish in the workshop?
 - How do I decide whether a suggested IRI is good enough to keep?
 - What does I-ADOPT clarify for measurement columns?
+- What can this review *not* decide for me?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::: objectives
 
-- Review one suggested `term_iri` for the Fraser Coho measurement without treating it as final.
-- Decompose that same measurement once using the SDP's I-ADOPT fields.
-- Review one unit IRI, one table observation-unit IRI, and one method-code IRI without confusing those links with I-ADOPT roles.
+- Build a review queue from the suggestions your package already carries, without running a new search.
+- Read one slot's shortlist and decide it with a call you paste into `scripts/build_sdp.R`.
+- Decompose one measurement once using the SDP's I-ADOPT fields.
+- Write the decisions back with `apply_sdp_semantics()` and confirm the data files did not change.
+- Name the decisions this review cannot reach, and say where they are still made.
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+```{r metasalmon-available, include = FALSE}
+# Runs when the lesson site is built. It proves the workshop's metasalmon
+# dependency loads and keeps {metasalmon} registered for sandpaper's renv
+# machinery, exactly as the same chunk does in Session 6.
+#
+# It deliberately does NOT assert that review_semantics() exists. The lesson's
+# renv lockfile pins one released metasalmon, and a hard assertion here would
+# turn "the pin is behind the release" into a failed website build. The note
+# below is the softer signal instead: it goes to stderr rather than through
+# message(), because include = FALSE discards captured messages and this one is
+# meant for the build log.
+#
+# Retires when: the lockfile pins a metasalmon that exports review_semantics().
+# Delete the whole `if` at that point; the library() call stays.
+library(metasalmon)
+
+if (!exists("review_semantics", where = asNamespace("metasalmon"), inherits = FALSE)) {
+  cat(
+    "NOTE: pinned metasalmon ", as.character(utils::packageVersion("metasalmon")),
+    " does not export review_semantics(); session-4.Rmd teaches it. ",
+    "Update renv/profiles/lesson-requirements/renv.lock.\n",
+    sep = "", file = stderr()
+  )
+}
+```
+
+## The decision that used to leave no record
+
+By the end of Session 3 your package was reproducible almost everywhere. `raw_data/` holds unchanged inputs, `scripts/build_sdp.R` turns them into a package, and rerunning the script rebuilds the same bytes.
+
+Almost everywhere. Until now, the documented way to accept a semantic link was to open `metadata/column_dictionary.csv` in a spreadsheet, read `semantic_suggestions.csv` beside it, and copy an IRI across by hand. That worked. But the only record it left was the changed cell. Six months later the cell says *what* was decided and nothing at all about *why*, *by whom*, or *what else was on the shortlist*. It was the one unreproducible link in a chain that is otherwise byte-for-byte reproducible.
+
+This chapter replaces that step. `review_semantics()` prints a shortlist and, under every candidate, the exact line of R that accepts it:
+
+```output
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable", rank = 1)
+```
+
+You paste that line into `scripts/build_sdp.R`. **The paste is the audit trail.** There is no prompt, no menu, and no interactive review screen, and that is a design decision rather than an omission: anything you answer at a prompt vanishes when the session ends, which would leave the decision exactly as unreproducible as the spreadsheet it replaces.
+
+A learner who understands why the spreadsheet was abandoned will not drift back to it. The spreadsheet lane still exists below, because a mixed workshop needs it — but it is now the lane that costs you the record, and this chapter says so plainly.
+
+::::::::::::::::::::::::::::::::::::: prereq
+
+## You need a metasalmon new enough to have the review flow
+
+`review_semantics()` and its companions are recent. Check before you start, and reinstall from the [metasalmon repository][metasalmon] if the answer is `FALSE`:
+
+```{r, eval = FALSE, purl = FALSE}
+packageVersion("metasalmon")
+exists("review_semantics", where = asNamespace("metasalmon"), inherits = FALSE)
+```
+
+The [changelog][metasalmon-changelog] names the release that introduced it.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Keep the workshop semantic review bounded
 
-In this workshop, we will not try to map every column. Everyone will use the NuSEDS Fraser Coho escapement example for one shared semantic-review exercise, even if you are also building a package from your own data. That gives the room one case to discuss and keeps the decisions small enough to finish.
+We will not try to map every column. Everyone will use the NuSEDS Fraser Coho escapement package from Session 2, even if you are also building a package from your own data. That gives the room one case to discuss and keeps the decisions small enough to finish.
 
-We will review exactly these linked decisions:
+We will decide exactly these linked slots:
 
-| Decision | SDP destination | Shared Fraser Coho example |
+| Decision | SDP destination | Shared Fraser Coho slot |
 | --- | --- | --- |
-| One complete measurement-variable IRI | `column_dictionary.csv$term_iri` | `NATURAL_SPAWNERS_TOTAL` |
-| One I-ADOPT decomposition | `property_iri`, `entity_iri`, and optional `constraint_iri` on that same dictionary row | abundance for natural-origin salmon in a conservation unit |
-| One simple unit | `column_dictionary.csv$unit_iri` | individuals |
-| What each table row represents | `tables.csv$observation_unit_iri` | an escapement estimate |
-| One method | `codes.csv$term_iri` for one `ESTIMATE_METHOD` value | `Area Under the Curve` |
+| One complete measurement variable | `column_dictionary.csv$term_iri` | `NATURAL_SPAWNERS_TOTAL` |
+| One I-ADOPT decomposition | `property_iri`, `entity_iri`, `constraint_iri` on that same row | abundance, of a population, natural-origin |
+| One unit | `column_dictionary.csv$unit_iri` | a count |
+| One statistical modifier | `column_dictionary.csv$statistical_modifier_iri` | a total |
+| What each table row represents | `tables.csv$observation_unit_iri` | an escapement |
+| One deliberate rejection | any slot | `AREA` |
 
-The method is a code-level example because the NuSEDS estimate method varies by row. It is not part of the I-ADOPT decomposition. Administrative IDs, file names, local notes, and the other categorical code lists can rely on clear descriptions for now and be mapped in a later review.
+Administrative IDs, file names, local notes, and the other categorical code lists can rely on clear descriptions for now and be mapped in a later review.
 
-## Generate suggestions for the shared example
+## Your package must already carry suggestions
 
-Continue with the NuSEDS Fraser Coho package from Session 2, even if you created another package from your own data in Session 3. The quickstart used `seed_semantics = FALSE`, so generate candidates now from the metadata you reviewed. If semantic seeding was already enabled for this package, its package-root `semantic_suggestions.csv` contains the original evidence; rerunning after metadata edits searches from the current package state.
+`review_semantics()` **never searches and never contacts a network or an LLM.** It reads the suggestions your package already has. That is why Session 3 turned `seed_semantics = TRUE` on: without it there is nothing to review, and the function says so rather than quietly returning an empty queue.
 
-The code below subsets the metadata before lookup, so deterministic search runs only for the shared measurement and table target. The `Area Under the Curve` method row is populated by the deterministic NuSEDS crosswalk during package creation, so this lesson reads and reviews that row instead of searching every method code again.
+```output
+Error in review_semantics(pkg_path) : No semantic suggestions to review.
+ℹ Run `suggest_semantics()`, or `create_sdp()` with `seed_semantics = TRUE`,
+  first.
+```
+
+If the Session 2 package was built with `seed_semantics = FALSE`, rebuild it once with seeding on before continuing. Expect the search itself to take a few minutes; that cost is paid once, at build time, and never again during review.
+
+## Build the review queue
 
 ::::::::::::::::::::::::::::::::::::: group-tab
 
 ### R
 
-```r
-example_pkg_path <- file.path(
-  "output",
-  "fraser-coho-example-sdp"
-)
+```{r, eval = FALSE, purl = FALSE}
+library(metasalmon)
 
-pkg <- read_salmon_datapackage(example_pkg_path)
+pkg_path <- file.path("output", "fraser-coho-example-sdp")
 
-measurement_dict <- pkg$dictionary |>
-  dplyr::filter(
-    column_name == "NATURAL_SPAWNERS_TOTAL"
-  )
+# One row per candidate; one queue entry per undecided slot. No search runs.
+review <- review_semantics(pkg_path)
 
-shared_table <- pkg$tables |>
-  dplyr::filter(table_id == "escapement")
+review
+```
 
-reviewed_dict <- suggest_semantics(
-  df = pkg$resources,
-  dict = measurement_dict,
-  table_meta = shared_table
-)
+To work through one column at a time, filter the queue:
 
-suggestions <- attr(reviewed_dict, "semantic_suggestions")
-
-bounded_suggestions <- suggestions |>
-  dplyr::filter(
-    (
-      target_scope == "column" &
-        column_name == "NATURAL_SPAWNERS_TOTAL" &
-        dictionary_role %in% c(
-          "variable",
-          "property",
-          "entity",
-          "constraint",
-          "unit"
-        )
-    ) |
-      (
-        target_scope == "table" &
-          target_sdp_field == "observation_unit_iri"
-      )
-  ) |>
-  dplyr::select(
-    target_scope,
-    column_name,
-    dictionary_role,
-    target_sdp_field,
-    label,
-    iri,
-    source,
-    definition
-  )
-
-method_example <- pkg$codes |>
-  dplyr::filter(
-    column_name == "ESTIMATE_METHOD",
-    code_value == "Area Under the Curve"
-  ) |>
-  dplyr::select(
-    column_name,
-    code_value,
-    term_iri
-  )
-
-bounded_suggestions
-method_example
+```{r, eval = FALSE, purl = FALSE}
+review <- review_semantics(pkg_path, columns = "NATURAL_SPAWNERS_TOTAL")
 ```
 
 ### Python
 
+`metasalmonpy` does not have this API yet. The R-native review flow lands in `metasalmon` first, and the Python equivalent is pending; there is nothing to demonstrate here that would still be true next month.
+
+What a Python user can do today is read the same evidence the R queue is built from. `semantic_suggestions.csv` sits at the package root and is written by both implementations:
+
 ```python
 from pathlib import Path
 
-from metasalmonpy import (
-    read_salmon_datapackage,
-    suggest_semantics,
+import pandas as pd
+
+pkg_path = Path("output") / "fraser-coho-example-sdp"
+
+suggestions = pd.read_csv(pkg_path / "semantic_suggestions.csv")
+
+print(
+    suggestions[
+        [
+            "column_name",
+            "dictionary_role",
+            "target_sdp_file",
+            "target_sdp_field",
+            "label",
+            "iri",
+            "source",
+            "score",
+        ]
+    ]
 )
-
-example_pkg_path = Path("output") / "fraser-coho-example-sdp"
-
-pkg = read_salmon_datapackage(example_pkg_path)
-
-measurement_dict = pkg["dictionary"].loc[
-    pkg["dictionary"]["column_name"].eq("NATURAL_SPAWNERS_TOTAL")
-]
-shared_table = pkg["tables"].loc[
-    pkg["tables"]["table_id"].eq("escapement")
-]
-
-reviewed_dict = suggest_semantics(
-    df=pkg["resources"],
-    dict_df=measurement_dict,
-    table_meta=shared_table,
-)
-
-suggestions = reviewed_dict.attrs["semantic_suggestions"]
-
-measurement_targets = (
-    suggestions["target_scope"].eq("column")
-    & suggestions["column_name"].eq("NATURAL_SPAWNERS_TOTAL")
-    & suggestions["dictionary_role"].isin(
-        ["variable", "property", "entity", "constraint", "unit"]
-    )
-)
-table_target = (
-    suggestions["target_scope"].eq("table")
-    & suggestions["target_sdp_field"].eq("observation_unit_iri")
-)
-
-bounded_suggestions = suggestions.loc[
-    measurement_targets | table_target,
-    [
-        "target_scope",
-        "column_name",
-        "dictionary_role",
-        "target_sdp_field",
-        "label",
-        "iri",
-        "source",
-        "definition",
-    ],
-]
-
-method_example = pkg["codes"].loc[
-    pkg["codes"]["column_name"].eq("ESTIMATE_METHOD")
-    & pkg["codes"]["code_value"].eq("Area Under the Curve"),
-    ["column_name", "code_value", "term_iri"],
-]
-
-print(bounded_suggestions)
-print(method_example)
 ```
+
+Decide from that table, then edit the target field in the canonical metadata CSV. Record each decision in `scripts/build_sdp.py` as a comment or an explicit assignment, so the reasoning survives the way the pasted R call does. Until the Python review flow ships, that discipline is manual rather than enforced.
 
 ### Spreadsheet
 
-Open an instructor-prepared `semantic_suggestions.csv` beside the NuSEDS Fraser Coho package metadata. Filter to `NATURAL_SPAWNERS_TOTAL` and the table observation-unit row. Then inspect the `Area Under the Curve` row in `metadata/codes.csv`. Compare each IRI, label, and definition with the source documentation and the data holder's explanation. Record **keep**, **replace**, **remove**, or **defer**; opening the CSV does not accept a suggestion or prove that a link is correct.
+Open `semantic_suggestions.csv` at the package root beside `metadata/column_dictionary.csv`. Filter to `NATURAL_SPAWNERS_TOTAL` and to the `tables.csv` row whose `target_sdp_field` is `observation_unit_iri`. Compare each `label`, `iri`, and `definition` with the source documentation and the data holder's explanation, then write the accepted IRI into the target field named by `target_sdp_file` and `target_sdp_field`.
+
+Be clear about the cost. This lane records the *outcome* and not the *reasoning*: nothing in the saved file says which other candidates you saw, or why you preferred this one. Keep a written review log beside the package so the next reader is not guessing. Opening the CSV does not accept a suggestion and is not evidence that a link is correct.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-Vocabulary lookup can take a few minutes. Omitting `sources` uses role-aware defaults. If you supply `sources` explicitly, current `metasalmon` and `metasalmonpy` treat the vector as a strict allowlist for the initial search and any LLM-requested bounded retry.
+## Read one slot
 
-At this stage, treat an empty or unexpected result as **unresolved**, not as proof that the vocabulary lacks an appropriate term. Leave that decision in review and continue with the shared example; a later workflow can distinguish a lookup problem from a genuine term gap.
+Each queue entry is one block. This is the `NATURAL_SPAWNERS_TOTAL` variable slot — the first block you see after filtering with `columns =` — printed exactly as it appears:
+
+```output
+── escapement · NATURAL_SPAWNERS_TOTAL · variable ────────────────────────────
+   field:   column_dictionary.csv · term_iri
+   current: REVIEW: https://w3id.org/gcdfo/salmon#SpawnerAbundance
+
+   [1] Spawner abundance   gcdfo   score 18.25
+       The abundance (count) of adult salmon that reach spawning grounds in a
+       given system and time period (often operationalized as
+       escapement/spawning escapement).
+       https://w3id.org/gcdfo/salmon#SpawnerAbundance
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable", rank = 1)
+
+       review <- reject_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable")   # no candidate fits
+```
+
+Read it in this order:
+
+- **the heading** — table, column, and semantic role;
+- **`field:`** — the exact file and column this decision writes into, so you can check the result yourself;
+- **`current:`** — what the field holds *now*;
+- **the shortlist** — `[1]`, `[2]`, … in the order the ranked search produced, each with its label, source vocabulary, score, definition, and IRI; and
+- **the calls** — one per candidate, plus one rejection.
+
+`current:` has three states, and the difference matters.
+
+| `current:` shows | What it means |
+| --- | --- |
+| `REVIEW: <iri>` | Seeding wrote a draft, because its unattended compatibility check passed. Still undecided. |
+| `<blank>` | Seeding found a candidate but declined to draft it. Still undecided, and the queue shows it for exactly that reason. |
+| `<unknown>` | The queue could not read the current value — the metadata row was missing or matched ambiguously. Read the CSV before deciding. |
+
+Undecided is undecided. A `REVIEW:` prefix is a marker meaning *nobody has looked at this*, not a weak endorsement, and strict validation refuses to publish a package that still contains one.
+
+The variable answers "what complete measurement is this column?" For `NATURAL_SPAWNERS_TOTAL` the candidate says spawner abundance, from `gcdfo`, with a definition that matches the NuSEDS field. Read the definition, not the label. Then accept it.
+
+## Decide, in your script
+
+`accept_suggestion()` and `reject_suggestion()` take a review and return a review. Nothing is written to disk until you say so, so a whole review is an ordinary re-runnable R script.
+
+::::::::::::::::::::::::::::::::::::: group-tab
+
+### R
+
+```{r, eval = FALSE, purl = FALSE}
+review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable", rank = 1)
+```
+
+Reject when nothing on the shortlist fits, and say why:
+
+```{r, eval = FALSE, purl = FALSE}
+review <- reject_suggestion(
+  review,
+  "AREA",
+  "variable",
+  reason = "DFO statistical area, not a body of water"
+)
+```
+
+`reason` is carried on the review object and shown in the console, and it reaches the package only as the word `rejected` in `semantic_suggestions.csv` — the sentence itself is not stored there. So the reason survives in exactly one place: the line you paste into your script. Write it as if that were true, because it is.
+
+Accept a term the search did not surface by naming it directly instead of a rank:
+
+```{r, eval = FALSE, purl = FALSE}
+review <- accept_suggestion(
+  review,
+  "NATURAL_SPAWNERS_TOTAL",
+  "property",
+  iri = "https://w3id.org/smn/Abundance"
+)
+```
+
+### Python
+
+Pending, as above. Apply the decision by editing the target field in the canonical metadata CSV named by `target_sdp_file` and `target_sdp_field`, and record the reasoning in `scripts/build_sdp.py`.
+
+### Spreadsheet
+
+Type the accepted IRI into the target field, with no `REVIEW:` prefix. Leave the field blank for a rejection and write the reason in your review log.
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+Two things make the printed call safe to paste rather than merely suggestive. The argument set is computed by *resolving* it, so `table =` and `code_value =` appear only when they are needed to address one slot and never otherwise. And the object name is read from your own binding — bind the review to `sem_review` and the printed calls say `sem_review <- accept_suggestion(sem_review, …)`.
+
+Mistakes are caught by name, not by silence:
+
+```output
+Error in accept_suggestion(sem_review, "FULL_CU", "variable", rank = 1) :
+  No review slot matches that column and role.
+✖ Asked for: FULL_CU · variable
+ℹ FULL_CU_IN · variable
+```
+
+```output
+Error in accept_suggestion(sem_review, "FULL_CU_IN", "variable", rank = 3) :
+  No candidate with that `rank` in this slot.
+ℹ Ranks available: 1.
+ℹ To accept a term that is not shortlisted, pass `iri` instead.
+```
+
+Read `Ranks available: 1.` literally. In the seeded Fraser Coho package, `semantic_suggestions.csv` carries exactly one row per slot rather than a whole ranked list, so every shortlist is one candidate deep and `rank = 1` is the only rank there is. "Accept rank 1" is therefore a much weaker statement than "the best of five" — it is closer to "accept or reject". When rank 1 is wrong, `iri =` is the way out, not rank 2.
 
 ## Treat suggestions as drafts
 
-Some tools write semantic suggestions directly into metadata as `REVIEW: <iri>`. That prefix is a warning, not approval.
+A score is a retrieval score. It measures how well a query matched a label and a definition; it is not agreement, and it is not evidence about your column.
+
+Here is the very first slot in the unfiltered Fraser Coho queue:
+
+```output
+── escapement · AREA · variable ──────────────────────────────────────────────
+   field:   column_dictionary.csv · term_iri
+   current: <blank>
+
+   [1] water body   ols   score 9.35
+       The term body of water most often refers to large accumulations of
+       water, such as oceans, seas, and lakes, but it includes smaller pools
+       of water such as ponds, wetlands, or more rarely, puddles. A body of
+       water does not have to be still or contained; Rivers, streams, canals,
+       and other geographical features where water moves from one place to
+       another are also considered bodies of water.
+       http://purl.obolibrary.org/obo/ENVO_00000063  https://www.ebi.ac.uk/ols4/ontologies/envo/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FENVO_00000063
+       review <- accept_suggestion(review, "AREA", "variable", rank = 1)
+
+       review <- reject_suggestion(review, "AREA", "variable")   # no candidate fits
+```
+
+`AREA` in NuSEDS is a DFO statistical management area — an administrative identifier. The top and only candidate is an ENVO class for a body of water. It scores 9.35 and it is wrong. Reject it.
+
+`WATERSHED_CDE` is the sharper case, and it is the reason step 2 of the checklist below is not redundant with step 1. Its top candidate is labelled **watershed**, which matches the column name about as well as a label can. Read the definition and it turns out to be *"the separation between neighbouring drainage basins"* — the divide, not the basin. The column stores neither: it stores a code. The label matched and the concept did not, which is precisely the failure a label-only check cannot see.
 
 Keep a suggested IRI only when:
 
@@ -201,71 +315,294 @@ Keep a suggested IRI only when:
 4. the unit is compatible with the values;
 5. the mapping does not erase an important caveat.
 
-If any check fails, replace it, remove it, or add it to the term-gap plan.
+If any check fails, reject it, supply the right IRI with `iri =`, or leave it for the term-gap workflow in Session 6.
 
-## Measurement semantics
+::::::::::::::::::::::::::::::::::::: callout
+
+## Where the second IRI on the line comes from
+
+Candidates retrieved through OLS print their IRI followed by a browsable OLS4 URL, because the IRI itself does not resolve to a human-readable page. In a terminal that supports hyperlinks you get one clickable label instead. Candidates from `smn`, `gcdfo`, and NVS print one IRI, because that IRI is already the page.
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+## Measurement semantics and I-ADOPT
 
 For `column_role = measurement`, SDP combines a variable link, I-ADOPT-style meaning components, a unit link, and an optional statistical-modifier link.
 
 | Field | Plain-language question |
 | --- | --- |
 | `term_iri` | What complete measurement variable is this? |
-| `property_iri` | I-ADOPT property: what characteristic is measured, such as count, length, mass, or temperature? |
+| `property_iri` | I-ADOPT property: what characteristic is measured — count, length, mass, temperature? |
 | `entity_iri` | I-ADOPT entity/object of interest: what is being measured? |
 | `constraint_iri` | Optional I-ADOPT constraint: what qualifier narrows the meaning? |
 | `unit_iri` | What unit are the values in? |
-| `statistical_modifier_iri` | Optional: is the column an aggregation or summary — a mean, maximum, minimum, total, or peak — rather than a single observation? |
+| `statistical_modifier_iri` | Optional: is the column an aggregation — a mean, maximum, minimum, total, or peak — rather than a single observation? |
 
-**Methods do not live in the column dictionary.** A method describes how a value was produced, not what the column is, so it is recorded where it is actually constant: a procedure shared by a whole table goes in `tables.csv$method_iri`, a citable protocol document goes in `protocol_iri`/`protocol_citation` on `tables.csv` or `dataset.csv`, and a method that varies row by row becomes a code column in the data whose values resolve through `codes.csv$term_iri` to shared-vocabulary procedures. A statistical modifier is the one kind of "how" that stays in the dictionary, because a *mean* weight and a *maximum* weight are different variables.
+The queue shows one slot per field, so the decomposition is decided one question at a time.
 
-Important boundary: `property_iri`, `entity_iri`, `constraint_iri`, and `statistical_modifier_iri` are I-ADOPT-style measurement-variable components. `unit_iri` is also measurement semantics, but units are not an I-ADOPT role, and methods are not part of the variable at all. Do not use these fields as general-purpose relationship fields for identifiers, attributes, or categorical columns.
+```output
+── escapement · NATURAL_SPAWNERS_TOTAL · property ────────────────────────────
+   field:   column_dictionary.csv · property_iri
+   current: REVIEW: https://w3id.org/gcdfo/salmon#SpawnerAbundance
+
+   [1] Spawner abundance   gcdfo   score 18.95
+       The abundance (count) of adult salmon that reach spawning grounds in a
+       given system and time period (often operationalized as
+       escapement/spawning escapement).
+       https://w3id.org/gcdfo/salmon#SpawnerAbundance
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "property", rank = 1)
+```
+
+This one deserves a stop. Retrieval offered the *same term* for `term_iri` and `property_iri`, and it cannot be right in both places: "spawner abundance" is a whole measurement variable, whereas the I-ADOPT property is the bare characteristic being measured. Decomposing a variable into itself records nothing. The property here is abundance:
+
+```{r, eval = FALSE, purl = FALSE}
+review <- accept_suggestion(
+  review,
+  "NATURAL_SPAWNERS_TOTAL",
+  "property",
+  iri = "https://w3id.org/smn/Abundance"
+)
+```
+
+This is the normal case for `iri =`, and it is worth naming as a general habit: when the property and the variable retrieve the same term, the property slot almost certainly needs a broader one.
+
+The remaining three slots:
+
+```output
+── escapement · NATURAL_SPAWNERS_TOTAL · entity ──────────────────────────────
+   field:   column_dictionary.csv · entity_iri
+   current: REVIEW: https://w3id.org/smn/Population
+
+   [1] Population   smn   score 15.55
+       A group of organisms of the same species occupying a defined area that
+       interbreed and share a gene pool. In salmon, populations are composed
+       of one or more demes and form the biological basis for Conservation
+       Units.
+       https://w3id.org/smn/Population
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "entity", rank = 1)
+
+── escapement · NATURAL_SPAWNERS_TOTAL · unit ────────────────────────────────
+   field:   column_dictionary.csv · unit_iri
+   current: REVIEW: http://qudt.org/vocab/unit/COUNT
+
+   [1] Count   qudt   score 4.65
+       http://qudt.org/vocab/unit/COUNT
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "unit", rank = 1)
+
+── escapement · NATURAL_SPAWNERS_TOTAL · constraint ──────────────────────────
+   field:   column_dictionary.csv · constraint_iri
+   current: REVIEW: https://w3id.org/smn/NaturalOrigin
+
+   [1] Natural-origin   smn   score 8.6
+       Individuals that are born and reared in the wild (natural
+       environment).
+       https://w3id.org/smn/NaturalOrigin
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "constraint", rank = 1)
+```
+
+Note the unit candidate: score 4.65 and no definition at all. A low score with nothing to read is a prompt to check the vocabulary yourself, not a reason to accept faster. Confirm that a count is what the NuSEDS column actually stores before keeping it.
+
+The statistical modifier is the one kind of "how" that stays in the dictionary, because a *mean* weight and a *maximum* weight are genuinely different variables:
+
+```output
+── escapement · NATURAL_SPAWNERS_TOTAL · statistical_modifier ────────────────
+   field:   column_dictionary.csv · statistical_modifier_iri
+   current: REVIEW: https://w3id.org/smn/TotalStatisticalModifier
+
+   [1] Total   smn   score 15.15
+       The reported value is the sum or cumulative total of the summarized
+       observations, such as an annual total catch or cumulative escapement.
+       https://w3id.org/smn/TotalStatisticalModifier
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "statistical_modifier", rank = 1)
+```
+
+The candidate is offered because the column name contains *TOTAL*. That is a name, not a fact about the values. Confirm with the data holder that the column really is a sum before accepting it; if you cannot confirm it, reject the slot rather than inheriting a claim from a column name.
+
+### The table slot has no column
+
+One queue entry is not about a column at all. `tables.csv$observation_unit_iri` records what one row of the table represents, so the printed call names the table instead:
+
+```output
+── escapement · entity ───────────────────────────────────────────────────────
+   field:   tables.csv · observation_unit_iri
+   current: REVIEW: https://w3id.org/smn/Escapement
+
+   [1] Escapement   smn   score 14.4
+       The number of mature salmon that pass through (or escape) fisheries
+       and return to fresh water to spawn.
+       https://w3id.org/smn/Escapement
+       review <- accept_suggestion(review, role = "entity", rank = 1, table = "escapement")
+```
+
+Paste it as printed. `columns =` filters on column names, so a `columns` filter always hides this slot; build the queue without one when you want to reach it.
+
+### Methods do not live in the column dictionary
+
+A method describes how a value was produced, not what the column *is*, so it is recorded where it is actually constant: a procedure shared by a whole table goes in `tables.csv$method_iri`; a citable protocol document goes in `protocol_iri`/`protocol_citation` on `tables.csv` or `dataset.csv`; and a method that varies row by row becomes a code column whose values resolve through `codes.csv$term_iri` to shared-vocabulary procedures.
+
+In the Fraser Coho package, `ESTIMATE_METHOD` is exactly that row-varying case, and metasalmon's deterministic NuSEDS crosswalk has already filled several of its code rows during package creation — `Area Under the Curve` resolves to `https://w3id.org/gcdfo/salmon#AreaUnderTheCurve` with no `REVIEW:` prefix at all. Those rows are written directly and produce no suggestions, so **they never appear in the review queue**. Open `metadata/codes.csv` and check them by eye. A crosswalk is a defensible default, not a decision you made.
+
+Important boundary: `property_iri`, `entity_iri`, `constraint_iri`, and `statistical_modifier_iri` are I-ADOPT-style measurement-variable components. `unit_iri` is measurement semantics too, but units are not an I-ADOPT role, and methods are not part of the variable at all. Do not use these fields as general-purpose relationship fields for identifiers, attributes, or categorical columns.
+
+## Write the decisions back
+
+Decisions live only in the review object until you apply them.
+
+::::::::::::::::::::::::::::::::::::: group-tab
+
+### R
+
+```{r, eval = FALSE, purl = FALSE}
+apply_sdp_semantics(pkg_path, review)
+```
+
+```output
+✔ Applied 8 semantic review decisions to 'output/fraser-coho-example-sdp'.
+ℹ Check the result with `validate_salmon_datapackage(path, require_iris =
+  TRUE)`.
+```
+
+### Python
+
+Pending. Edit the target metadata CSV fields directly, then revalidate.
+
+### Spreadsheet
+
+Save the metadata CSVs you edited, keeping the header row and column order unchanged.
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+`apply_sdp_semantics()` is deliberately narrow, and the narrowness is the safety property:
+
+- accepted IRIs are written with the `REVIEW:` prefix stripped;
+- rejected slots are cleared;
+- **undecided slots are left exactly as they were**, `REVIEW:` markers and all;
+- `term_type` is kept in step with `term_iri`, so the dictionary never claims a kind for a term it no longer holds;
+- `datapackage.json` and `semantic_suggestions.csv` are updated in the same transaction, because the descriptor duplicates the dictionary's IRI fields and a half-applied edit would leave the package quietly self-inconsistent; and
+- **no data CSV byte is touched.**
+
+That last point is the difference from `write_salmon_datapackage()`, which rebuilds a whole package from in-memory objects. Applying a review is a surgical metadata edit. Applying the same review twice produces identical bytes, which is what makes it safe to leave in a build script that runs every day.
+
+Check the claim rather than believing it — the file hash of `data/escapement.csv` is the same before and after:
+
+```{r, eval = FALSE, purl = FALSE}
+before <- tools::md5sum(file.path(pkg_path, "data", "escapement.csv"))
+
+apply_sdp_semantics(pkg_path, review)
+
+identical(before, tools::md5sum(file.path(pkg_path, "data", "escapement.csv")))
+#> TRUE
+```
+
+Rebuild the queue afterwards and it is shorter: the slots you decided now hold final IRIs, so they drop out.
+
+```{r, eval = FALSE, purl = FALSE}
+review_semantics(pkg_path)
+```
+
+## The finished script
+
+Session 3 said every accepted decision belongs in the script rather than in a manual edit inside `output/`. This is what that looks like for semantics. Append it to `scripts/build_sdp.R`, below the `create_sdp()` call:
+
+```{r, eval = FALSE, purl = FALSE}
+review <- review_semantics(pkg_path)
+
+review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable", rank = 1)
+review <- accept_suggestion(
+  review, "NATURAL_SPAWNERS_TOTAL", "property",
+  iri = "https://w3id.org/smn/Abundance"          # the shortlist offered the whole variable
+)
+review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "entity", rank = 1)
+review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "unit", rank = 1)
+review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "constraint", rank = 1)
+review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "statistical_modifier", rank = 1)
+review <- accept_suggestion(review, role = "entity", rank = 1, table = "escapement")
+
+review <- reject_suggestion(
+  review, "AREA", "variable",
+  reason = "DFO statistical area, not a body of water"
+)
+
+apply_sdp_semantics(pkg_path, review)
+
+validate_salmon_datapackage(pkg_path, require_iris = FALSE)
+```
+
+Every line is a decision, every decision can carry its reasoning in a comment beside it, and the whole thing reruns. That is the property the spreadsheet could not give you.
+
+Expect `validate_salmon_datapackage()` to still warn here: the slots you did not decide keep their `REVIEW:` markers, and the free-text placeholders are untouched. That is the correct state for a package mid-review.
+
+One caveat about rerunning. The decisions replay deterministically, but the *candidates* do not: shared vocabularies evolve, so a future `create_sdp(seed_semantics = TRUE)` may retrieve a different shortlist and `rank = 1` may then name a different term. Where an accepted IRI must never drift, write it as `iri = "…"` instead of `rank = 1`. That converts a position into a commitment.
+
+## What this review cannot decide
+
+Say these out loud in the workshop. A tool that hides its limits teaches learners to trust it in the places it is weakest.
+
+**A slot with no candidate never appears.** The queue is built from shortlists, not from gaps. A required field that retrieval found nothing for is silently absent from the review, so a completed review can still fail `require_iris = TRUE`. The validation report — not the empty queue — is the authority on whether the package is finished.
+
+**An empty queue is not proof of completion.** Filter to a column that does not exist and the console still reports "No unfilled semantic slots with suggestions", which reads like success. Check the column name before believing it.
+
+**Free-text fields are still edited by hand.** Descriptions, contacts, licences, and the other `MISSING …:` placeholders are outside this flow; strict validation reports them as errors. Session 6 covers that gate.
+
+**Rejections do not persist into a fresh queue.** `apply_sdp_semantics()` records the rejection in `semantic_suggestions.csv` and clears the field — but a blank field is undecided, so calling `review_semantics()` again re-queues the slot you rejected, with no sign that you already looked at it. Your script is the record; the queue is not. This is a real rough edge, and it is another reason the decisions belong in `scripts/build_sdp.R`.
+
+**Some suggestion targets are not decidable here at all.** A target that has no single IRI field to write into — the dataset keyword list, for example — is reported and skipped rather than shown as something you can accept. Edit those in the metadata CSVs directly.
 
 ## Optional LLM-assisted bundle review
 
-Adding `llm_assess = TRUE` in R or `llm_assess=True` in Python, plus an approved provider and model, asks the LLM to judge the retrieved candidates; it does not let the model invent IRIs. A measurement's variable, property, entity, unit, constraint, and statistical-modifier candidates are reviewed together as one bundle. A statistical-modifier candidate is proposed only when the column's name, label, or description names an aggregation such as total, mean, maximum, minimum, or peak. Method candidates apply to code values, where codes can resolve to shared `sosa:Procedure` concepts.
+This is a **separate step, and it is strictly opt-in.** Nothing in this chapter contacts an LLM: `review_semantics()`, `accept_suggestion()`, `reject_suggestion()`, and `apply_sdp_semantics()` make no network call of any kind. LLM assessment happens earlier, during `suggest_semantics()` or `create_sdp()`, and only when you pass `llm_assess = TRUE` in R or `llm_assess=True` in Python together with an approved provider and model. Supplying context files alone never triggers a call.
 
-The package clients bound retries for temporary provider failures and keep credentials out of reported URLs. These safeguards reduce avoidable failures; they do not authorize unbounded retries, sensitive context, or unattended acceptance of LLM decisions.
+When suggestions were generated that way, the review console surfaces the assessment under the candidate as an extra `llm:` line with its decision, confidence, and rationale. It surfaces it; it never generates it. If you did not opt in, those lines simply are not there.
 
-Deterministic validators can downgrade an unsupported `accept` decision to `review`, but they never substitute or invent a term. Suggested candidates written into the dictionary carry the `REVIEW:` prefix until a person confirms them.
+What the assessment is allowed to do is judge the retrieved candidates. It cannot invent an IRI. A measurement's variable, property, entity, unit, constraint, and statistical-modifier candidates are reviewed together as one bundle, and a statistical-modifier candidate is proposed only when the column's name, label, or description names an aggregation. Deterministic validators can downgrade an unsupported `accept` to `review`, but they never substitute a term.
 
-Context files must be passed as existing local file paths through `llm_context_files`, and context alone does not enable an LLM call. Use only an approved provider and appropriate non-sensitive context.
+Context files must be passed as existing local file paths through `llm_context_files`, never as parsed data frames or documents. Use only an approved provider and non-sensitive context. An LLM decision is evidence for your review, not a replacement for it: you still paste the call.
 
-## Example review
+## Function reference
 
-Shared example column: `NATURAL_SPAWNERS_TOTAL`
-
-| Decision | Fraser Coho candidate to review |
-| --- | --- |
-| Complete measurement variable, `term_iri` | Natural-origin spawner abundance; review `https://w3id.org/gcdfo/salmon#SpawnerAbundance` against the NuSEDS definition. |
-| I-ADOPT property, `property_iri` | Abundance; review `https://w3id.org/smn/Abundance`. |
-| I-ADOPT entity, `entity_iri` | The conservation unit recorded in `FULL_CU_IN`; review `https://w3id.org/gcdfo/salmon#ConservationUnit`. |
-| I-ADOPT constraint, `constraint_iri` | Natural origin; review `https://w3id.org/smn/NaturalOrigin`. |
-| Unit, `unit_iri` | Individuals; review `https://qudt.org/vocab/unit/INDIV`. This is measurement semantics, but not an I-ADOPT role. |
-| Statistical modifier | Leave blank for this exercise; do not infer *total*, *peak*, or *mean* without confirming what the source value represents. |
-| Table observation unit | Each row reports an escapement estimate; review `https://w3id.org/smn/EscapementEstimate` for `tables.csv$observation_unit_iri`. |
-| Method | `ESTIMATE_METHOD` varies by row. Review the `Area Under the Curve` code mapping to `https://w3id.org/gcdfo/salmon#AreaUnderTheCurve` in `codes.csv$term_iri`; do not put it in the measurement's I-ADOPT fields. |
+Full argument lists and return values: [`review_semantics()`][metasalmon-review-semantics], [`accept_suggestion()` and `reject_suggestion()`][metasalmon-accept-suggestion], [`apply_sdp_semantics()`][metasalmon-apply-sdp-semantics].
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
 ## Challenge 1: Complete the bounded Fraser Coho review
 
-Work with the shared NuSEDS Fraser Coho package, even if you brought your own dataset. Complete only this review:
+Work with the shared NuSEDS Fraser Coho package, even if you brought your own dataset.
 
-1. choose **keep**, **replace**, **remove**, or **defer** for the one `NATURAL_SPAWNERS_TOTAL` `term_iri` candidate, and write one sentence explaining why;
-2. complete one I-ADOPT decomposition of that same measurement by reviewing its property, entity, and natural-origin constraint;
-3. review the QUDT Individual unit IRI;
-4. review the escapement-estimate IRI that says what each table row represents; and
-5. review the `Area Under the Curve` method-code IRI in `codes.csv`.
+1. Build the queue with `review_semantics()` and count the slots.
+2. Decide the six `NATURAL_SPAWNERS_TOTAL` slots: variable, property, entity, unit, constraint, statistical modifier. Use `iri =` where the shortlist is wrong, and write one sentence in the script saying why.
+3. Decide the table observation-unit slot.
+4. Reject `AREA` with a reason.
+5. Apply the decisions and confirm `data/escapement.csv` is byte-identical.
+6. Open `metadata/codes.csv` and check the `ESTIMATE_METHOD` rows the crosswalk filled. Which would you keep? Which would you question?
 
-Do not map additional fields during this exercise. After the workshop, use the same sequence for another measurement in your own package.
+Do not map additional fields during this exercise.
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::: challenge
+
+## Challenge 2: Prove the review is reproducible
+
+Delete `output/fraser-coho-example-sdp/` and rerun `scripts/build_sdp.R` from the top. Budget a few minutes: this reruns the seeding search as well as the review.
+
+- Does the package come back with the same accepted IRIs?
+- Which of your decisions would survive a vocabulary change, and which are pinned to `rank = 1`?
+- Rerun `apply_sdp_semantics()` a second time without changing anything. What changed on disk?
+- Rebuild the queue after applying. Which slots came back, and why?
+
+Then answer the question this chapter exists for: **if you left this project today, what would the next person be able to reconstruct — and what would they have to guess?**
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::: keypoints
 
-- The workshop semantic exercise is bounded to one Fraser Coho measurement, one I-ADOPT decomposition, one unit, one table observation unit, and one method code.
-- `REVIEW:` suggestions are evidence to inspect, not final answers.
-- Optional LLM review selects from deterministic candidates and remains subject to deterministic checks.
-- SDP measurement semantic fields are measurement-only in the column dictionary; methods live at the table, protocol, or code level rather than in the dictionary, and I-ADOPT itself does not model units or methods.
+- The console prints the exact `accept_suggestion()` call; pasting it into your build script is what makes the decision reproducible.
+- `review_semantics()` reads suggestions that already exist. It never searches, and it never contacts an LLM.
+- `REVIEW:` and a blank field both mean undecided; a retrieval score is not agreement.
+- The workshop review is bounded to one measurement, its I-ADOPT decomposition, its unit and statistical modifier, one table observation unit, and one deliberate rejection.
+- I-ADOPT roles describe the measurement variable; units are separate, and methods live at the table, protocol, or code level rather than in the dictionary.
+- `apply_sdp_semantics()` is a surgical, re-runnable metadata edit that leaves the data files byte-identical.
+- The queue shows shortlists, not gaps — the validation report decides whether the package is finished.
+- Optional LLM assessment is generated earlier and only on explicit opt-in; the review flow only displays it.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/session-4.Rmd
+++ b/episodes/session-4.Rmd
@@ -66,6 +66,8 @@ You paste that line into `scripts/build_sdp.R`. **The paste is the audit trail.*
 
 A learner who understands why the spreadsheet was abandoned will not drift back to it. The spreadsheet lane still exists below, because a mixed workshop needs it — but it is now the lane that costs you the record, and this chapter says so plainly.
 
+Be precise about the size of the claim. **Semantic IRI review no longer needs a spreadsheet.** That is not the same as "you never open a spreadsheet again": free-text fields — descriptions, contacts, licences — are still edited by hand, and a slot that retrieval found nothing for never reaches this review at all. The section [What this review cannot decide](#what-this-review-cannot-decide) is not a disclaimer at the end; it is half the lesson. A learner who leaves believing review finishes the package will be corrected by the validator, and will trust the tool less than it deserves.
+
 ::::::::::::::::::::::::::::::::::::: prereq
 
 ## You need a metasalmon new enough to have the review flow
@@ -135,9 +137,9 @@ review <- review_semantics(pkg_path, columns = "NATURAL_SPAWNERS_TOTAL")
 
 ### Python
 
-`metasalmonpy` does not have this API yet. The R-native review flow lands in `metasalmon` first, and the Python equivalent is pending; there is nothing to demonstrate here that would still be true next month.
+**There is no Python equivalent.** Not a partial one, not a differently-spelled one: `metasalmonpy` has no review queue, no accessor for the suggestions attribute, and no function that reads `semantic_suggestions.csv` back. The R-native review flow lands in `metasalmon` first, and the port has not been written. This is a gap, not a deliberate parity difference, so do not go looking for it in the [parity guide][metasalmonpy-parity].
 
-What a Python user can do today is read the same evidence the R queue is built from. `semantic_suggestions.csv` sits at the package root and is written by both implementations:
+What a Python user can do today is read the same evidence the R queue is built from, with pandas rather than with `metasalmonpy`. `semantic_suggestions.csv` sits at the package root and is written by both implementations:
 
 ```python
 from pathlib import Path
@@ -277,7 +279,61 @@ Error in accept_suggestion(sem_review, "FULL_CU_IN", "variable", rank = 3) :
 ℹ To accept a term that is not shortlisted, pass `iri` instead.
 ```
 
-Read `Ranks available: 1.` literally. In the seeded Fraser Coho package, `semantic_suggestions.csv` carries exactly one row per slot rather than a whole ranked list, so every shortlist is one candidate deep and `rank = 1` is the only rank there is. "Accept rank 1" is therefore a much weaker statement than "the best of five" — it is closer to "accept or reject". When rank 1 is wrong, `iri =` is the way out, not rank 2.
+Read `Ranks available: 1.` literally, because it is the most misleading-looking thing on the page. **`create_sdp()` keeps one candidate per role by default** — `semantic_max_per_role = 1` — so the seeded `semantic_suggestions.csv` carries one row per slot rather than a ranked list, and every shortlist you have seen so far is one candidate deep. `rank = 1` is the only rank there is. "Accept rank 1" is therefore a much weaker statement than "the best of five": it is closer to "accept or reject".
+
+Ask for a deeper shortlist at build time, not at review time. The review reads what seeding stored, so this is a `create_sdp()` argument:
+
+```{r, eval = FALSE, purl = FALSE}
+pkg_path <- create_sdp(
+  fraser_coho,
+  path = file.path("output", "fraser-coho-example-sdp"),
+  dataset_id = "fraser-coho-example",
+  table_id = "escapement",
+  seed_semantics = TRUE,
+  semantic_max_per_role = 3,
+  check_updates = FALSE,
+  overwrite = TRUE
+)
+```
+
+The same slot then offers three:
+
+```output
+── escapement · NATURAL_SPAWNERS_TOTAL · variable ────────────────────────────
+   field:   column_dictionary.csv · term_iri
+   current: REVIEW: https://w3id.org/gcdfo/salmon#SpawnerAbundance
+
+   [1] Spawner abundance   gcdfo   score 18.25
+       The abundance (count) of adult salmon that reach spawning grounds in a
+       given system and time period (often operationalized as
+       escapement/spawning escapement).
+       https://w3id.org/gcdfo/salmon#SpawnerAbundance
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable", rank = 1)
+
+   [2] Relative hatchery spawner abundance   gcdfo   score 15.25
+       Hatchery-origin spawner abundance expressed as a relative
+       (dimensionless) abundance metric to a defined reference (commonly
+       benchmarks), for within-series comparison; in rapid-status workflows,
+       relative abundance is computed using the current generational average
+       (geometric mean) divided by CU-specific lower and/or upper benchmarks.
+       https://w3id.org/gcdfo/salmon#RelativeHatcherySpawnerAbundance
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable", rank = 2)
+
+   [3] Relative hatchery spawner abundance change   gcdfo   score 15.25
+       A change metric (delta or percent change, as defined by the workflow)
+       computed from relative hatchery-origin spawner abundance values over
+       time; in rapid-status workflows, percent change is derived from
+       log-transformed series and quantified over the most recent three
+       generations.
+       https://w3id.org/gcdfo/salmon#RelativeHatcherySpawnerAbundanceChange
+       review <- accept_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable", rank = 3)
+
+       review <- reject_suggestion(review, "NATURAL_SPAWNERS_TOTAL", "variable")   # no candidate fits
+```
+
+Notice what a deeper shortlist actually bought: ranks 2 and 3 are *hatchery*-origin terms, for a column of *natural*-origin spawners. More candidates gave you more to rule out, not more to choose from — which is useful, and is not the same as more confidence. Depth costs seeding time on every column, so raise it when you are doing careful work on a narrow table, not by default.
+
+Either way, when rank 1 is wrong the reliable escape is `iri =`, not rank 2.
 
 ## Treat suggestions as drafts
 
@@ -322,6 +378,16 @@ If any check fails, reject it, supply the right IRI with `iri =`, or leave it fo
 ## Where the second IRI on the line comes from
 
 Candidates retrieved through OLS print their IRI followed by a browsable OLS4 URL, because the IRI itself does not resolve to a human-readable page. In a terminal that supports hyperlinks you get one clickable label instead. Candidates from `smn`, `gcdfo`, and NVS print one IRI, because that IRI is already the page.
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::: callout
+
+## What you read is what the vocabulary says
+
+Definitions come from third parties, and some of them contain characters that mean something to R's message formatter. A definition reading *"…returning to spawn in a stream {reach}"* prints exactly that, braces included. The review console emits its lines with `cat()` rather than through a message template, so ontology text is never interpreted — you are reading the definition, not a rendering of it.
+
+That matters for review: a definition that had been silently reformatted, truncated at a brace, or replaced by a formatting error would be the one piece of evidence you most need intact.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -500,6 +566,43 @@ Rebuild the queue afterwards and it is shorter: the slots you decided now hold f
 review_semantics(pkg_path)
 ```
 
+### The decision that stays in the package
+
+Your script is the record of *why*. `semantic_suggestions.csv` now also records *which* — `apply_sdp_semantics()` writes a `decision` column beside the candidates it was choosing between:
+
+```{r, eval = FALSE, purl = FALSE}
+suggestions <- readr::read_csv(
+  file.path(pkg_path, "semantic_suggestions.csv"),
+  show_col_types = FALSE
+)
+
+suggestions[!is.na(suggestions$decision), c("column_name", "dictionary_role", "decision")]
+```
+
+```output
+# A tibble: 8 × 3
+  column_name            dictionary_role      decision
+  <chr>                  <chr>                <chr>
+1 AREA                   variable             rejected
+2 NATURAL_SPAWNERS_TOTAL variable             accepted
+3 NATURAL_SPAWNERS_TOTAL property             not_selected
+4 NATURAL_SPAWNERS_TOTAL entity               accepted
+5 NATURAL_SPAWNERS_TOTAL unit                 accepted
+6 NATURAL_SPAWNERS_TOTAL constraint           accepted
+7 NATURAL_SPAWNERS_TOTAL statistical_modifier accepted
+8 <NA>                   entity               accepted
+```
+
+Row 8 has no `column_name` because it is the table observation-unit slot.
+
+This is the first durable, in-package record of a review decision, and it travels with the package rather than with your project folder. Three values appear:
+
+- `accepted` — this candidate was chosen;
+- `rejected` — the slot was rejected, so no candidate was chosen; and
+- `not_selected` — this candidate was on the shortlist and lost. The `property` row reads `not_selected` because we accepted `smn:Abundance` with `iri =` instead of the shortlisted term.
+
+Read the `property` row as the useful case: it is the one that tells a later reader the shortlist was overruled, which is exactly the fact a copied cell used to hide.
+
 ## The finished script
 
 Session 3 said every accepted decision belongs in the script rather than in a manual edit inside `output/`. This is what that looks like for semantics. Append it to `scripts/build_sdp.R`, below the `create_sdp()` call:
@@ -599,6 +702,8 @@ Then answer the question this chapter exists for: **if you left this project tod
 - The console prints the exact `accept_suggestion()` call; pasting it into your build script is what makes the decision reproducible.
 - `review_semantics()` reads suggestions that already exist. It never searches, and it never contacts an LLM.
 - `REVIEW:` and a blank field both mean undecided; a retrieval score is not agreement.
+- Shortlists are one candidate deep by default (`semantic_max_per_role = 1`); ask for depth at build time, and expect it to give you more to reject rather than more to accept.
+- Semantic IRI review no longer needs a spreadsheet. Free text still does, and gaps never enter the queue at all.
 - The workshop review is bounded to one measurement, its I-ADOPT decomposition, its unit and statistical modifier, one table observation unit, and one deliberate rejection.
 - I-ADOPT roles describe the measurement variable; units are separate, and methods live at the table, protocol, or code level rather than in the dictionary.
 - `apply_sdp_semantics()` is a surgical, re-runnable metadata edit that leaves the data files byte-identical.

--- a/episodes/session-4.Rmd
+++ b/episodes/session-4.Rmd
@@ -29,25 +29,10 @@ exercises: 40
 # dependency loads and keeps {metasalmon} registered for sandpaper's renv
 # machinery, exactly as the same chunk does in Session 6.
 #
-# It deliberately does NOT assert that review_semantics() exists. The lesson's
-# renv lockfile pins one released metasalmon, and a hard assertion here would
-# turn "the pin is behind the release" into a failed website build. The note
-# below is the softer signal instead: it goes to stderr rather than through
-# message(), because include = FALSE discards captured messages and this one is
-# meant for the build log.
-#
-# Retires when: the lockfile pins a metasalmon that exports review_semantics().
-# Delete the whole `if` at that point; the library() call stays.
+# The build-log note that used to sit here — warning that the pinned metasalmon
+# did not export review_semantics() — was removed when the lockfile moved to
+# v0.5.0, which is the retirement condition it named for itself.
 library(metasalmon)
-
-if (!exists("review_semantics", where = asNamespace("metasalmon"), inherits = FALSE)) {
-  cat(
-    "NOTE: pinned metasalmon ", as.character(utils::packageVersion("metasalmon")),
-    " does not export review_semantics(); session-4.Rmd teaches it. ",
-    "Update renv/profiles/lesson-requirements/renv.lock.\n",
-    sep = "", file = stderr()
-  )
-}
 ```
 
 ## The decision that used to leave no record
@@ -66,20 +51,19 @@ You paste that line into `scripts/build_sdp.R`. **The paste is the audit trail.*
 
 A learner who understands why the spreadsheet was abandoned will not drift back to it. The spreadsheet lane still exists below, because a mixed workshop needs it — but it is now the lane that costs you the record, and this chapter says so plainly.
 
-Be precise about the size of the claim. **Semantic IRI review no longer needs a spreadsheet.** That is not the same as "you never open a spreadsheet again": free-text fields — descriptions, contacts, licences — are still edited by hand, and a slot that retrieval found nothing for never reaches this review at all. The section [What this review cannot decide](#what-this-review-cannot-decide) is not a disclaimer at the end; it is half the lesson. A learner who leaves believing review finishes the package will be corrected by the validator, and will trust the tool less than it deserves.
+Be precise about the size of the claim. **This chapter's flow decides semantic IRIs, and it is not the whole package.** Free-text fields — descriptions, contacts, licences — are outside it, and a slot that retrieval found nothing for never reaches this queue at all. Neither of those is a spreadsheet job any more: `review_metadata()` and the `set_sdp_*()` setters, which shipped in the same release, close both, and the section [What this review cannot decide](#what-this-review-cannot-decide) is where they are named. That section is not a disclaimer at the end; it is half the lesson. A learner who leaves believing *this queue* finishes the package will be corrected by the validator, and will trust the tool less than it deserves.
 
 ::::::::::::::::::::::::::::::::::::: prereq
 
-## You need a metasalmon new enough to have the review flow
+## You need metasalmon 0.5.0 or newer
 
-`review_semantics()` and its companions are recent. Check before you start, and reinstall from the [metasalmon repository][metasalmon] if the answer is `FALSE`:
+The review flow shipped in **metasalmon 0.5.0**. Check before you start, and reinstall the pinned tag from the Setup page if the answer is older:
 
 ```{r, eval = FALSE, purl = FALSE}
 packageVersion("metasalmon")
-exists("review_semantics", where = asNamespace("metasalmon"), inherits = FALSE)
 ```
 
-The [changelog][metasalmon-changelog] names the release that introduced it.
+An earlier metasalmon loads without complaint and then has none of the functions this chapter uses. The [changelog][metasalmon-changelog] has the 0.5.0 entry.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -138,6 +122,8 @@ review <- review_semantics(pkg_path, columns = "NATURAL_SPAWNERS_TOTAL")
 ### Python
 
 **There is no Python equivalent.** Not a partial one, not a differently-spelled one: `metasalmonpy` has no review queue, no accessor for the suggestions attribute, and no function that reads `semantic_suggestions.csv` back. The R-native review flow lands in `metasalmon` first, and the port has not been written. This is a gap, not a deliberate parity difference, so do not go looking for it in the [parity guide][metasalmonpy-parity].
+
+This is also why the Setup page pins the two lanes to different releases: metasalmon `v0.5.0` is the release this chapter teaches, and metasalmonpy's newest is `v0.4.0`. Pinning both makes the lesson reproducible; only the port will make it equivalent.
 
 What a Python user can do today is read the same evidence the R queue is built from, with pandas rather than with `metasalmonpy`. `semantic_suggestions.csv` sits at the package root and is written by both implementations:
 
@@ -238,7 +224,7 @@ review <- reject_suggestion(
 )
 ```
 
-`reason` is carried on the review object and shown in the console, and it reaches the package only as the word `rejected` in `semantic_suggestions.csv` — the sentence itself is not stored there. So the reason survives in exactly one place: the line you paste into your script. Write it as if that were true, because it is.
+`reason` is carried on the review object, shown in the console, **and written to disk** — `semantic_suggestions.csv` has a `decision_reason` column beside `decision`, so the sentence travels with the package rather than only with your project folder. Write it for a reader who has neither your script nor you: it is the one field that says why a slot is deliberately empty rather than merely unfinished.
 
 Accept a term the search did not surface by naming it directly instead of a rank:
 
@@ -603,6 +589,17 @@ This is the first durable, in-package record of a review decision, and it travel
 
 Read the `property` row as the useful case: it is the one that tells a later reader the shortlist was overruled, which is exactly the fact a copied cell used to hide.
 
+A fourth column, `decision_reason`, carries the sentence you passed to `reject_suggestion()`. Add it to the selection above to see it:
+
+```{r, eval = FALSE, purl = FALSE}
+suggestions[
+  !is.na(suggestions$decision),
+  c("column_name", "dictionary_role", "decision", "decision_reason")
+]
+```
+
+`review_semantics()` reads that column back, so rebuilding the queue tomorrow keeps your rejections out of it instead of asking the same question again.
+
 ## The finished script
 
 Session 3 said every accepted decision belongs in the script rather than in a manual edit inside `output/`. This is what that looks like for semantics. Append it to `scripts/build_sdp.R`, below the `create_sdp()` call:
@@ -641,15 +638,33 @@ One caveat about rerunning. The decisions replay deterministically, but the *can
 
 Say these out loud in the workshop. A tool that hides its limits teaches learners to trust it in the places it is weakest.
 
-**A slot with no candidate never appears.** The queue is built from shortlists, not from gaps. A required field that retrieval found nothing for is silently absent from the review, so a completed review can still fail `require_iris = TRUE`. The validation report — not the empty queue — is the authority on whether the package is finished.
+**A slot with no candidate never appears in *this* queue.** `review_semantics()` is built from shortlists, not from gaps, so a required field that retrieval found nothing for is silently absent from it. That is a property of the semantic queue, not a limit of the package: `review_metadata()` reads the package against the rules that actually decide strict validation — the schema's required fields, the `MISSING …:` placeholders, the measurement-IRI requirement and the table observation-unit requirement — so a field no retrieval ever touched is as visible to it as one with five candidates. Run it after this chapter, and treat *its* report, rather than an empty semantic queue, as the authority on whether the package is finished.
 
-**An empty queue is not proof of completion.** Filter to a column that does not exist and the console still reports "No unfilled semantic slots with suggestions", which reads like success. Check the column name before believing it.
+**Free-text fields have their own R-native flow, and it is not this one.** Descriptions, contacts, licences and the other `MISSING …:` placeholders are outside the semantic review, but they are no longer a spreadsheet job either. `review_metadata()` prints the exact `set_sdp_dataset()` / `set_sdp_table()` / `set_sdp_column()` / `set_sdp_code()` call for each one, with the value left as a `<…>` placeholder you replace:
 
-**Free-text fields are still edited by hand.** Descriptions, contacts, licences, and the other `MISSING …:` placeholders are outside this flow; strict validation reports them as errors. Session 6 covers that gate.
+```{r, eval = FALSE, purl = FALSE}
+review_metadata(pkg_path)
 
-**Rejections do not persist into a fresh queue.** `apply_sdp_semantics()` records the rejection in `semantic_suggestions.csv` and clears the field — but a blank field is undecided, so calling `review_semantics()` again re-queues the slot you rejected, with no sign that you already looked at it. Your script is the record; the queue is not. This is a real rough edge, and it is another reason the decisions belong in `scripts/build_sdp.R`.
+set_sdp_dataset(pkg_path,
+  creator = "Fisheries and Oceans Canada - Pacific Region"
+)
+```
 
-**Some suggestion targets are not decidable here at all.** A target that has no single IRI field to write into — the dataset keyword list, for example — is reported and skipped rather than shown as something you can accept. Edit those in the metadata CSVs directly.
+The same rule as this chapter applies: **the printed call is the contract, and the paste is the audit trail.** Pasting one unedited is refused — a `creator` field reading `<add creator, team, or originating program>` would pass strict validation while saying nothing, which is worse than the placeholder it replaced, because the marker is gone. Session 6 covers where that gate sits in the publication workflow.
+
+**Some suggestion targets are not decidable in the semantic queue.** A target with no single IRI field to write into — the dataset keyword list, for example — is reported and skipped rather than shown as something you can accept. Set those with `set_sdp_dataset(pkg_path, keywords = "…")`, which checks the field name against the schema, so a misspelling is an error rather than a silent no-op.
+
+::::::::::::::::::::::::::::::::::::: callout
+
+## Two rough edges this chapter used to carry, and where they went
+
+Earlier drafts of this lesson taught two real defects, because they were real: a rejection did not survive rebuilding the queue, and an empty queue under a mistyped `columns` filter printed the *completion* message — telling a learner who typed `columns = "TYPO"` that their package was finished.
+
+Both were fixed in **metasalmon 0.5.0**, and both were found by teaching this API rather than by testing it. `review_semantics()` now replays recorded decisions and keeps decided slots out of the default queue (pass `include_filled = TRUE` to see them), the rejection *reason* is written to a `decision_reason` column and read back, and a `columns` value matching no column is an error that names the columns that do exist.
+
+They are worth naming rather than quietly deleting. The shared shape is the lesson: **a feature that writes a record and never reads it back has not been round-tripped, and no test that only writes will say so.**
+
+::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Optional LLM-assisted bundle review
 
@@ -663,7 +678,7 @@ Context files must be passed as existing local file paths through `llm_context_f
 
 ## Function reference
 
-Full argument lists and return values: [`review_semantics()`][metasalmon-review-semantics], [`accept_suggestion()` and `reject_suggestion()`][metasalmon-accept-suggestion], [`apply_sdp_semantics()`][metasalmon-apply-sdp-semantics].
+Full argument lists and return values: [`review_semantics()`][metasalmon-review-semantics], [`accept_suggestion()` and `reject_suggestion()`][metasalmon-accept-suggestion], [`apply_sdp_semantics()`][metasalmon-apply-sdp-semantics], [`review_metadata()`][metasalmon-review-metadata], and the [`set_sdp_*()` setters][metasalmon-set-sdp-dataset].
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
@@ -703,11 +718,11 @@ Then answer the question this chapter exists for: **if you left this project tod
 - `review_semantics()` reads suggestions that already exist. It never searches, and it never contacts an LLM.
 - `REVIEW:` and a blank field both mean undecided; a retrieval score is not agreement.
 - Shortlists are one candidate deep by default (`semantic_max_per_role = 1`); ask for depth at build time, and expect it to give you more to reject rather than more to accept.
-- Semantic IRI review no longer needs a spreadsheet. Free text still does, and gaps never enter the queue at all.
+- No part of getting a package to strict validation needs a spreadsheet any more: this queue decides the IRIs, and `review_metadata()` plus the `set_sdp_*()` setters decide the free text and the gaps this queue never shows.
 - The workshop review is bounded to one measurement, its I-ADOPT decomposition, its unit and statistical modifier, one table observation unit, and one deliberate rejection.
 - I-ADOPT roles describe the measurement variable; units are separate, and methods live at the table, protocol, or code level rather than in the dictionary.
 - `apply_sdp_semantics()` is a surgical, re-runnable metadata edit that leaves the data files byte-identical.
-- The queue shows shortlists, not gaps — the validation report decides whether the package is finished.
+- The queue shows shortlists, not gaps — `review_metadata()` shows the gaps, and the validation report decides whether the package is finished.
 - Optional LLM assessment is generated earlier and only on explicit opt-in; the review flow only displays it.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -140,7 +140,7 @@ Before delivery:
 - choose a small example dataset;
 - prepare an RStudio Project containing `raw_data/`, `scripts/`, and `output/`, with the example's data and context inputs together under `raw_data/` and an R or Python build script under `scripts/`;
 - prepare one current, already-created SDP folder for later review after the high-level system overview and quickstart;
-- install the latest R/`metasalmon` and Python/`metasalmonpy` packages and verify the examples in each language being taught;
+- install the pinned releases — R/`metasalmon` **v0.5.0** and Python/`metasalmonpy` **v0.4.0**, per `learners/setup.md` — and verify the examples in each language being taught. The two numbers differ on purpose: Session 4's review flow shipped in metasalmon 0.5.0 and has no Python port yet;
 - prepare one measurement mapping example;
 - prepare semantic suggestion output in advance if live vocabulary lookup would interrupt the schedule. Seeding the shared Fraser Coho example takes roughly three minutes of live vocabulary lookup on a 17-column table, so build it before the session and hand out the folder; Session 4's review itself makes no network call and is instant;
 - prepare one categorical code-list example;

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -19,6 +19,7 @@ Say "link to a shared definition" before introducing "semantic link" or "semanti
 Repeat these messages throughout:
 
 - A clear description is better than a forced IRI.
+- A decision that is not in the script did not happen. The pasted call is the audit trail.
 - Not every field needs an ontology term.
 - Measurement columns deserve the most careful semantic review.
 - Local context should be preserved and mapped, not renamed away.
@@ -99,8 +100,10 @@ After Session 3:
 After Session 4:
 
 - Which measurement mappings are accepted?
-- Which are removed or deferred?
+- Which are rejected, and is the reason recorded in the script rather than only in the room?
+- Can a learner point at the line in `scripts/build_sdp.R` that made each decision, and rerun it?
 - Are units treated separately from I-ADOPT roles, statistical modifiers used only for aggregations, and methods placed at the table, protocol, or code level rather than in the dictionary?
+- Can they say what the review queue does *not* show them?
 
 After Sessions 5 and 6:
 
@@ -117,6 +120,10 @@ After Sessions 5 and 6:
 
 - Learners try to fill every semantic field. Redirect to "measurements first."
 - Learners trust `REVIEW:` suggestions. Ask them to read the definition and scope.
+- Learners read the retrieval score as a confidence score. It is neither. `AREA` in the shared example retrieves an ENVO body of water at score 9.35 and is wrong; use it as the worked counterexample.
+- Learners assume `rank = 1` was the best of several. In a one-shot seeded package each slot's shortlist is one candidate deep, so `rank = 1` is usually the only rank there is. Show them `Ranks available: 1.`
+- Learners decide in the console and never paste the call into the script. That is the spreadsheet problem in a new costume; stop and have them paste before moving on.
+- Learners treat an empty review queue as a finished package. The queue shows shortlists, not gaps; the validation report is the authority.
 - Groups debate ontology classes too early. Bring them back to the package row, column, code value, or caveat.
 - Local method bins get proposed as shared terms. Ask whether another organization would use the same definition.
 - Participants add extra columns to canonical metadata CSVs. Put extra context in the README or sidecar notes instead.
@@ -135,7 +142,7 @@ Before delivery:
 - prepare one current, already-created SDP folder for later review after the high-level system overview and quickstart;
 - install the latest R/`metasalmon` and Python/`metasalmonpy` packages and verify the examples in each language being taught;
 - prepare one measurement mapping example;
-- prepare semantic suggestion output in advance if live vocabulary lookup would interrupt the schedule;
+- prepare semantic suggestion output in advance if live vocabulary lookup would interrupt the schedule. Seeding the shared Fraser Coho example takes roughly three minutes of live vocabulary lookup on a 17-column table, so build it before the session and hand out the folder; Session 4's review itself makes no network call and is instant;
 - prepare one categorical code-list example;
 - prepare one unresolved term with routing rationale;
 - if demonstrating optional LLM review, use an approved provider and non-sensitive context, and show how bundle decisions can be downgraded to manual review;

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -6,7 +6,7 @@ title: Reference
 
 1. Create a draft package from one table or a named list of tables.
 2. Improve dataset, table, column, code, and README/context descriptions.
-3. Review suggested semantic links.
+3. Review suggested semantic links, recording each decision as a line of code in the build script rather than as an edited cell.
 4. Focus first on measurements, units, observation units, and important code lists.
 5. Render and review unresolved-term routes: `smn`, `gcdfo`, `profile`, or `skip`.
 6. Run strict validation only when the SDP is final enough for publication.
@@ -20,6 +20,9 @@ title: Reference
 | Create a package | `metasalmon::create_sdp()` | `metasalmonpy.create_sdp()` |
 | Read a package | `read_salmon_datapackage()` | `read_salmon_datapackage()` |
 | Suggest shared definitions | `suggest_semantics()` | `suggest_semantics()` |
+| Build a semantic review queue | `review_semantics()` | pending |
+| Decide one review slot | `accept_suggestion()`, `reject_suggestion()` | pending |
+| Write review decisions back | `apply_sdp_semantics()` | pending |
 | Detect unresolved gaps | `detect_semantic_term_gaps()` | `detect_semantic_term_gaps()` |
 | Render request drafts | `render_ontology_term_request()` | `render_ontology_term_request()` |
 | Validate during review | `validate_salmon_datapackage(..., require_iris = FALSE)` | `validate_salmon_datapackage(..., require_iris=False)` |
@@ -28,6 +31,8 @@ title: Reference
 | Plan or run a KNB deposit | `publish_sdp_to_knb()` | `publish_sdp_to_knb()` (requires the `knb` extra) |
 
 The two implementations are maintained at behavioral parity and release in lockstep. Their syntax remains idiomatic to each language; see the [metasalmonpy parity guide][metasalmonpy-parity] for deliberate differences. Install the latest packages before the workshop.
+
+Rows marked *pending* are the R-native semantic review flow, which lands in `metasalmon` first. It is not a deliberate parity difference; the Python equivalent has not shipped yet. Python users decide the same slots by reading `semantic_suggestions.csv` and editing the target metadata field named by its `target_sdp_file` and `target_sdp_field` columns.
 
 ## Recommended project layout
 

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -23,6 +23,8 @@ title: Reference
 | Build a semantic review queue | `review_semantics()` | pending |
 | Decide one review slot | `accept_suggestion()`, `reject_suggestion()` | pending |
 | Write review decisions back | `apply_sdp_semantics()` | pending |
+| Report required-but-unfilled metadata | `review_metadata()` | pending |
+| Fill a free-text metadata field | `set_sdp_dataset()`, `set_sdp_table()`, `set_sdp_column()`, `set_sdp_code()` | pending |
 | Detect unresolved gaps | `detect_semantic_term_gaps()` | `detect_semantic_term_gaps()` |
 | Render request drafts | `render_ontology_term_request()` | `render_ontology_term_request()` |
 | Validate during review | `validate_salmon_datapackage(..., require_iris = FALSE)` | `validate_salmon_datapackage(..., require_iris=False)` |
@@ -30,7 +32,7 @@ title: Reference
 | Export validated EML | `write_eml_from_sdp()` | `write_eml_from_sdp()` (requires the `eml` extra) |
 | Plan or run a KNB deposit | `publish_sdp_to_knb()` | `publish_sdp_to_knb()` (requires the `knb` extra) |
 
-The two implementations are maintained at behavioral parity and release in lockstep. Their syntax remains idiomatic to each language; see the [metasalmonpy parity guide][metasalmonpy-parity] for deliberate differences. Install the latest packages before the workshop.
+The two implementations are maintained at behavioral parity and normally release in lockstep. Their syntax remains idiomatic to each language; see the [metasalmonpy parity guide][metasalmonpy-parity] for deliberate differences. Install the **pinned** releases before the workshop — `metasalmon` v0.5.0 and `metasalmonpy` v0.4.0 — not the latest default branch; the Setup page has both commands and says why the numbers differ.
 
 Rows marked *pending* are the R-native semantic review flow, which lands in `metasalmon` first. It is not a deliberate parity difference; the Python equivalent has not shipped yet. Python users decide the same slots by reading `semantic_suggestions.csv` and editing the target metadata field named by its `target_sdp_file` and `target_sdp_field` columns.
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -66,16 +66,20 @@ Required:
 - RStudio, Positron, or another R editor; and
 - the `remotes`, `readr`, `dplyr`, `purrr`, `readxl`, and `metasalmon` packages.
 
-Install or update to the latest version from GitHub before the workshop:
+Install the release this lesson is written against, `v0.5.0`, before the workshop:
 
 ```r
 install.packages(c("remotes", "readr", "dplyr", "purrr", "readxl"))
-remotes::install_github("salmon-data-mobilization/metasalmon")
+remotes::install_github("salmon-data-mobilization/metasalmon@v0.5.0")
 
 packageVersion("metasalmon")
 ```
 
-Facilitators should review the [metasalmon changelog][metasalmon-changelog] when preparing to teach.
+`packageVersion("metasalmon")` should report `0.5.0`. Install the pinned tag rather than the default branch: `v0.5.0` is the same release recorded in this lesson's own `renv.lock`, so the code you run locally is the code the lesson site was built with. An unpinned install tracks whatever has landed on `main` since, which is how a lesson and a learner quietly stop agreeing.
+
+`v0.5.0` is the release that added the R-native review and editing flow Session 4 teaches — `review_semantics()`, `accept_suggestion()`, `reject_suggestion()`, `apply_sdp_semantics()`, `review_metadata()` and the `set_sdp_*()` setters. An earlier metasalmon will load, and Session 4 will not run.
+
+Facilitators should review the [metasalmon changelog][metasalmon-changelog] when preparing to teach, and bump both the tag above and the lockfile together when the workshop moves to a newer release.
 
 For validated EML export, also install:
 
@@ -101,19 +105,29 @@ LLM review is strictly opt-in. Context supplied through `llm_context_files` must
 
 `metasalmonpy` is the Python implementation of the `metasalmon` workflow. The two packages are maintained at behavioral parity and their releases move in lockstep; deliberate, language-idiomatic differences are documented in the [parity guide][metasalmonpy-parity]. Use the Python examples anywhere the workshop presents a Python lane.
 
+**The two lanes are pinned to different releases right now, and that is deliberate.** metasalmon is at `v0.5.0` and metasalmonpy is at `v0.4.0`: the R-native review flow Session 4 teaches has not been ported to Python yet. Pinning the Python lane to its own newest release fixes *reproducibility* — you and the lesson site run the same code — and does not close that gap. Session 4 says where its Python lane is empty and shows a `pandas` read of `semantic_suggestions.csv` instead.
+
 Required:
 
 - Python 3.9 or newer; and
 - a terminal, notebook, or Python editor.
 
-Create an environment and install or update to the latest version directly from GitHub (no Git installation required):
+Create an environment and install the pinned release directly from GitHub (no Git installation required). The releases carry no wheel assets, so the tag tarball is the pinned artifact:
 
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install \
-  "metasalmonpy @ https://github.com/salmon-data-mobilization/metasalmonpy/archive/refs/heads/main.tar.gz"
+  "metasalmonpy @ https://github.com/salmon-data-mobilization/metasalmonpy/archive/refs/tags/v0.4.0.tar.gz"
 ```
+
+Confirm the installed release:
+
+```bash
+python -c "import metasalmonpy; print(metasalmonpy.__version__)"
+```
+
+That should print `0.4.0`. As in the R lane, install the tag rather than the default branch.
 
 The installed package and Python import are both named `metasalmonpy`. See the [metasalmonpy documentation][metasalmonpy-docs]. Validated EML export uses the optional `eml` extra, and KNB publication uses the optional `knb` extra. To prepare for both, replace `metasalmonpy` with `metasalmonpy[knb]` in the install command above; the `knb` extra includes EML support.
 
@@ -157,8 +171,8 @@ Before the demo, confirm that:
 - `raw_data/`, `scripts/`, and `output/` exist;
 - your prepared data and context files are under `raw_data/`, or you plan to run the included example unchanged;
 - R or Python users have a place for `scripts/build_sdp.R` or `scripts/build_sdp.py`;
-- R users can load `metasalmon` with `library(metasalmon)`;
-- Python users can import `metasalmonpy`; and
+- R users can load `metasalmon` with `library(metasalmon)`, and `packageVersion("metasalmon")` reports `0.5.0`;
+- Python users can import `metasalmonpy`, and `metasalmonpy.__version__` reports `0.4.0`; and
 - spreadsheet users can open the blank SDP CSV template in their editor.
 
 If your organization restricts software installation, use the spreadsheet lane for the package-structure and metadata-review activities.

--- a/links.md
+++ b/links.md
@@ -8,6 +8,9 @@
 [metasalmon-eml-reference]: https://github.com/salmon-data-mobilization/metasalmon/blob/main/man/write_eml_from_sdp.Rd
 [metasalmon-knb-reference]: https://github.com/salmon-data-mobilization/metasalmon/blob/main/man/publish_sdp_to_knb.Rd
 [metasalmon-chat-decomposition]: https://salmon-data-mobilization.github.io/metasalmon/reference/chat_decomposition.html
+[metasalmon-review-semantics]: https://salmon-data-mobilization.github.io/metasalmon/reference/review_semantics.html
+[metasalmon-accept-suggestion]: https://salmon-data-mobilization.github.io/metasalmon/reference/accept_suggestion.html
+[metasalmon-apply-sdp-semantics]: https://salmon-data-mobilization.github.io/metasalmon/reference/apply_sdp_semantics.html
 [metasalmon-llm-review]: https://salmon-data-mobilization.github.io/metasalmon/articles/llm-context-review.html
 [metasalmonpy]: https://github.com/salmon-data-mobilization/metasalmonpy
 [metasalmonpy-docs]: https://salmon-data-mobilization.github.io/metasalmonpy/

--- a/links.md
+++ b/links.md
@@ -11,6 +11,8 @@
 [metasalmon-review-semantics]: https://salmon-data-mobilization.github.io/metasalmon/reference/review_semantics.html
 [metasalmon-accept-suggestion]: https://salmon-data-mobilization.github.io/metasalmon/reference/accept_suggestion.html
 [metasalmon-apply-sdp-semantics]: https://salmon-data-mobilization.github.io/metasalmon/reference/apply_sdp_semantics.html
+[metasalmon-review-metadata]: https://salmon-data-mobilization.github.io/metasalmon/reference/review_metadata.html
+[metasalmon-set-sdp-dataset]: https://salmon-data-mobilization.github.io/metasalmon/reference/set_sdp_dataset.html
 [metasalmon-llm-review]: https://salmon-data-mobilization.github.io/metasalmon/articles/llm-context-review.html
 [metasalmonpy]: https://github.com/salmon-data-mobilization/metasalmonpy
 [metasalmonpy-docs]: https://salmon-data-mobilization.github.io/metasalmonpy/

--- a/renv/profiles/lesson-requirements/renv.lock
+++ b/renv/profiles/lesson-requirements/renv.lock
@@ -70,10 +70,11 @@
     },
     "base64enc": {
       "Package": "base64enc",
-      "Version": "0.1-3",
+      "Version": "0.1-6",
       "Source": "Repository",
-      "Title": "Tools for base64 encoding",
-      "Author": "Simon Urbanek <Simon.Urbanek@r-project.org>",
+      "Title": "Tools for 'base64' Encoding",
+      "Author": "Simon Urbanek [aut, cre, cph] (https://urbanek.nz, ORCID: <https://orcid.org/0000-0003-2297-1732>)",
+      "Authors@R": "person(\"Simon\", \"Urbanek\", role=c(\"aut\",\"cre\",\"cph\"), email=\"Simon.Urbanek@r-project.org\", comment=c(\"https://urbanek.nz\", ORCID=\"0000-0003-2297-1732\"))",
       "Maintainer": "Simon Urbanek <Simon.Urbanek@r-project.org>",
       "Depends": [
         "R (>= 2.9.0)"
@@ -81,9 +82,10 @@
       "Enhances": [
         "png"
       ],
-      "Description": "This package provides tools for handling base64 encoding. It is more flexible than the orphaned base64 package.",
+      "Description": "Tools for handling 'base64' encoding. It is more flexible than the orphaned 'base64' package.",
       "License": "GPL-2 | GPL-3",
-      "URL": "http://www.rforge.net/base64enc",
+      "URL": "https://www.rforge.net/base64enc",
+      "BugReports": "https://github.com/s-u/base64enc/issues",
       "NeedsCompilation": "yes",
       "Repository": "CRAN"
     },
@@ -1363,7 +1365,7 @@
     },
     "metasalmon": {
       "Package": "metasalmon",
-      "Version": "0.3.0",
+      "Version": "0.5.0",
       "Source": "GitHub",
       "Type": "Package",
       "Title": "Utilities for Salmon Data Packages",
@@ -1421,8 +1423,8 @@
       "RemoteHost": "api.github.com",
       "RemoteUsername": "salmon-data-mobilization",
       "RemoteRepo": "metasalmon",
-      "RemoteRef": "v0.3.0",
-      "RemoteSha": "5a37b11b40782df8a63370294b3f744a5309e8e5"
+      "RemoteRef": "v0.5.0",
+      "RemoteSha": "af84689df5d6365c1abaa49f8cd9012cbe8494c5"
     },
     "mime": {
       "Package": "mime",
@@ -2566,21 +2568,28 @@
     },
     "yaml": {
       "Package": "yaml",
-      "Version": "2.3.10",
+      "Version": "2.3.12",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Methods to Convert R Data to YAML and Back",
-      "Date": "2024-07-22",
-      "Suggests": [
-        "RUnit"
-      ],
-      "Author": "Shawn P Garbett [aut], Jeremy Stephens [aut, cre], Kirill Simonov [aut], Yihui Xie [ctb], Zhuoer Dong [ctb], Hadley Wickham [ctb], Jeffrey Horner [ctb], reikoch [ctb], Will Beasley [ctb], Brendan O'Connor [ctb], Gregory R. Warnes [ctb], Michael Quinn [ctb], Zhian N. Kamvar [ctb], Charlie Gao [ctb]",
-      "Maintainer": "Shawn Garbett <shawn.garbett@vumc.org>",
-      "License": "BSD_3_clause + file LICENSE",
+      "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"cre\", comment = c(ORCID = \"0000-0003-4757-117X\")), person(\"Shawn\", \"Garbett\", , \"shawn.garbett@vumc.org\", role = \"ctb\", comment = c(ORCID = \"0000-0003-4079-5621\")), person(\"Jeremy\", \"Stephens\", role = c(\"aut\", \"ctb\")), person(\"Kirill\", \"Simonov\", role = \"aut\"), person(\"Yihui\", \"Xie\", role = \"ctb\", comment = c(ORCID = \"0000-0003-0645-5666\")), person(\"Zhuoer\", \"Dong\", role = \"ctb\"), person(\"Jeffrey\", \"Horner\", role = \"ctb\"), person(\"reikoch\", role = \"ctb\"), person(\"Will\", \"Beasley\", role = \"ctb\", comment = c(ORCID = \"0000-0002-5613-5006\")), person(\"Brendan\", \"O'Connor\", role = \"ctb\"), person(\"Michael\", \"Quinn\", role = \"ctb\"), person(\"Charlie\", \"Gao\", role = \"ctb\"), person(c(\"Gregory\", \"R.\"), \"Warnes\", role = \"ctb\"), person(c(\"Zhian\", \"N.\"), \"Kamvar\", role = \"ctb\") )",
       "Description": "Implements the 'libyaml' 'YAML' 1.1 parser and emitter (<https://pyyaml.org/wiki/LibYAML>) for R.",
-      "URL": "https://github.com/vubiostat/r-yaml/",
-      "BugReports": "https://github.com/vubiostat/r-yaml/issues",
+      "License": "BSD_3_clause + file LICENSE",
+      "URL": "https://yaml.r-lib.org, https://github.com/r-lib/yaml/",
+      "BugReports": "https://github.com/r-lib/yaml/issues",
+      "Suggests": [
+        "knitr",
+        "rmarkdown",
+        "testthat (>= 3.0.0)"
+      ],
+      "Config/testthat/edition": "3",
+      "Config/Needs/website": "tidyverse/tidytemplate",
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.3",
+      "VignetteBuilder": "knitr",
       "NeedsCompilation": "yes",
+      "Author": "Hadley Wickham [cre] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Shawn Garbett [ctb] (ORCID: <https://orcid.org/0000-0003-4079-5621>), Jeremy Stephens [aut, ctb], Kirill Simonov [aut], Yihui Xie [ctb] (ORCID: <https://orcid.org/0000-0003-0645-5666>), Zhuoer Dong [ctb], Jeffrey Horner [ctb], reikoch [ctb], Will Beasley [ctb] (ORCID: <https://orcid.org/0000-0002-5613-5006>), Brendan O'Connor [ctb], Michael Quinn [ctb], Charlie Gao [ctb], Gregory R. Warnes [ctb], Zhian N. Kamvar [ctb]",
+      "Maintainer": "Hadley Wickham <hadley@posit.co>",
       "Repository": "CRAN"
     },
     "zip": {

--- a/renv/profiles/lesson-requirements/renv.lock
+++ b/renv/profiles/lesson-requirements/renv.lock
@@ -982,7 +982,7 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.8.1",
+      "Version": "0.5.9",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Tools for HTML",
@@ -1016,10 +1016,10 @@
       "Config/Needs/check": "knitr",
       "Config/Needs/website": "rstudio/quillt, bench",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.1",
+      "RoxygenNote": "7.3.3",
       "Collate": "'colors.R' 'fill.R' 'html_dependency.R' 'html_escape.R' 'html_print.R' 'htmltools-package.R' 'images.R' 'known_tags.R' 'selector.R' 'staticimports.R' 'tag_query.R' 'utils.R' 'tags.R' 'template.R'",
       "NeedsCompilation": "yes",
-      "Author": "Joe Cheng [aut], Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>), Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>), Winston Chang [aut] (<https://orcid.org/0000-0002-1576-2126>), Yihui Xie [aut], Jeff Allen [aut], Posit Software, PBC [cph, fnd]",
+      "Author": "Joe Cheng [aut], Carson Sievert [aut, cre] (ORCID: <https://orcid.org/0000-0002-4958-2844>), Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>), Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>), Yihui Xie [aut], Jeff Allen [aut], Posit Software, PBC [cph, fnd]",
       "Maintainer": "Carson Sievert <carson@posit.co>",
       "Repository": "CRAN"
     },


### PR DESCRIPTION
Teach shortlist depth, the decision column, and the honest boundary

Verified against metasalmon main at 1ba5e1f, where S5 M1-M3 is now merged.

- Name semantic_max_per_role = 1 as the reason every shortlist is one
  candidate deep, and show a real three-deep shortlist from a rebuild with
  semantic_max_per_role = 3. Ranks 2 and 3 turn out to be hatchery-origin
  terms for a natural-origin column, which makes the honest point: depth
  buys you more to reject, not more to accept.
- Show the decision column apply_sdp_semantics() writes into
  semantic_suggestions.csv. It is the first durable in-package record of a
  review decision, and the not_selected row is the one that says the
  shortlist was overruled.
- State the size of the claim up front: semantic IRI review no longer needs
  a spreadsheet, which is not "you never open Excel again". Free text is
  still hand-edited and gaps never enter the queue.
- Say plainly that metasalmonpy has no port at all, and that this is a gap
  rather than a parity deviation.
- Note that ontology text with braces prints literally, because the console
  emits via cat() rather than a message template.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
Brett's instruction 2026-08-25: *"I want you to re-write the review chapter and overrule collisions."* This replaces parts of `24b9da3`; the PR body records what was kept and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update 2026-08-25: metasalmon v0.5.0 is released, so this chapter's three blockers are gone

metasalmon [`v0.5.0`](https://github.com/salmon-data-mobilization/metasalmon/releases/tag/v0.5.0) released roadmap stream S5 — the flow this chapter teaches. Two commits land the workshop side here, deliberately in this PR rather than a separate one: **moving the pin and deleting the now-false caveats have to be one change**, or the lesson claims a capability its build environment lacks.

### 1. Both install lanes name a release (`learners/setup.md`)

R pins `metasalmon@v0.5.0`; Python pins the `metasalmonpy` **v0.4.0** tag tarball, replacing the untagged-`main` installs on both lanes.

**The two numbers differ on purpose.** metasalmonpy has none of S5, so pinning it fixes reproducibility on that lane and does **not** close the capability gap. Its review rows in the cheat sheet stay marked *pending*, and this chapter's Python section still says the lane is empty.

### 2. The lockfile moves to `v0.5.0` — and CI's real failure turned out to be something else

`renv/profiles/lesson-requirements/renv.lock` pinned metasalmon **0.3.0**, which is what the published site builds against. Snapshotted through `sandpaper::manage_deps()` from the lesson-requirements profile, not hand-edited; a second run is a clean no-op.

The `Receive Pull Request` check has failed on **every** recent PR here — including `fix/2026-08-21-currency-pass`, which merged — reporting eleven packages `renv::restore` could not install, metasalmon among them. That reads like the stale pin's dependency tree. **It is not.** The runner is R 4.6.1, and the log's actual error is:

```
base64enc.so: undefined symbol: SETLENGTH
```

`base64enc` 0.1-3 and `yaml` 2.3.10 both predate R 4.6 withdrawing those non-API entry points. The other nine are cascade failures downstream of exactly those two — including metasalmon's own, which the log spells out as `dependency failed (usethis, yaml)`.

**Confirmed by running it, in two rounds.** Bumping `base64enc` → 0.1-6 and `yaml` → 2.3.12 took the failure list from eleven packages to six: both installed, and the error moved to `htmltools` 0.5.8.1 reporting the identical `htmltools.so: undefined symbol: SETLENGTH`, with the other five named only as *"dependency failed (htmltools, …)"*. `htmltools` → 0.5.9 in a second commit. **The check is now green** — the first green `Receive Pull Request` on a workshop PR in this series.

Scope note: the lockfile holds **thirteen** compiled packages with a newer CRAN version, and this bumps only the three CI actually failed on. Several of the rest are major bumps (`curl` 7 → 8, `fs` 1 → 2, `jsonlite` 1 → 2) with nothing yet saying they are needed. If a fourth `SETLENGTH` failure ever appears, that is the point to decide whether the lockfile wants a wholesale refresh rather than another single bump.

So **moving the metasalmon pin alone would not have fixed CI**: metasalmon's `Imports` are byte-identical between 0.3.0 and 0.5.0. This PR also bumps `base64enc` → 0.1-6 and `yaml` → 2.3.12, the minimal change that addresses the measured cause. They are infrastructure packages and touch no lesson content — say the word if you would rather they moved in their own PR.

### 3. The build-log guard is retired, and four caveats went false

The `if (!exists("review_semantics", ...))` block at the top of `episodes/session-4.Rmd` is deleted; `library(metasalmon)` stays. The chunk's own comment named its retirement condition — *"the lockfile pins a metasalmon that exports `review_semantics()`"* — and the lockfile now does.

Four published statements went false with 0.5.0 and are corrected rather than left standing:

| Caveat as published | State at 0.5.0 |
|---|---|
| A completed review can still fail `require_iris = TRUE`, with nowhere in R to go | `review_metadata()` reads the package against the rules that decide strict validation, so a gap is as visible as a shortlist |
| Free-text fields are still edited by hand | `set_sdp_dataset()` / `set_sdp_table()` / `set_sdp_column()` / `set_sdp_code()` |
| Rejections do not persist into a fresh queue | Decisions replay; the reason reaches disk in a `decision_reason` column |
| An empty queue under a mistyped `columns` filter reads as success | An error that names the columns that do exist |

The last two are named as **fixed** in a callout rather than quietly deleted, because the shape they shared is the transferable lesson: *a feature that writes a record and never reads it back has not been round-tripped, and no test that only writes will say so.*

### Verification

`sandpaper::validate_lesson()` clean, and a full `sandpaper::build_lesson()` clean — no errors, no warnings, and no `NOTE: pinned metasalmon …` line in the build log. **CI green**, including the `Receive Pull Request` check that has failed on every recent PR here.

### Conflicts with PR #5

**PR #5 touches `learners/setup.md` and the same lockfile entry, pinning both to `v0.4.0`.** That was correct when it was written and is one release stale for the R lane now. Whichever merges second will need those two files reconciled toward **metasalmon v0.5.0 / metasalmonpy v0.4.0**; PR #5's `session-6`, `reference.md` and `README` content does not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

